### PR TITLE
Memory leaks & valgrind fixes

### DIFF
--- a/ytnef/src/ytnef/vcal.c
+++ b/ytnef/src/ytnef/vcal.c
@@ -486,7 +486,7 @@ void SaveVCalendar(TNEFStruct TNEF, int isMtgReq) {
     if ((filename = MAPIFindUserProp(&(TNEF.MapiProperties),
                                      PROP_TAG(PT_BOOLEAN, 0x8506))) != MAPI_UNDEFINED) {
       ddword_ptr = (DDWORD *)filename->data;
-      ddword_val = SwapDDWord((BYTE *)ddword_ptr);
+      ddword_val = SwapDDWord((BYTE *)ddword_ptr, 8);
       fprintf(fptr, "CLASS:");
       if (*ddword_ptr == 1) {
         fprintf(fptr, "PRIVATE\n");

--- a/ytnef/src/ytnef/vtask.c
+++ b/ytnef/src/ytnef/vtask.c
@@ -138,7 +138,7 @@ void SaveVTask(TNEFStruct TNEF) {
                                 PROP_TAG(PT_BOOLEAN, 0x8506));
     if (filename != MAPI_UNDEFINED) {
       ddword_ptr = (DDWORD *)filename->data;
-      ddword_val = SwapDDWord((BYTE *)ddword_ptr);
+      ddword_val = SwapDDWord((BYTE *)ddword_ptr, 8);
       fprintf(fptr, "CLASS:");
       if (*ddword_ptr == 1) {
         fprintf(fptr, "PRIVATE\n");

--- a/ytneflib/ytnef.h
+++ b/ytneflib/ytnef.h
@@ -25,8 +25,8 @@
 #include "mapi.h"
 #include "mapidefs.h"
 #define STD_ARGLIST (TNEFStruct *TNEF, int id, char *data, int size)
-DWORD SwapDWord(BYTE *p);
-WORD SwapWord(BYTE *p);
+DWORD SwapDWord(BYTE *p, int size);
+WORD SwapWord(BYTE *p, int size);
 
 
 void TNEFInitMapi(MAPIProps *p);
@@ -45,9 +45,9 @@ int MAPISysTimetoDTR(BYTE *data, dtr *thedate);
 void MAPIPrint(MAPIProps *p);
 void TNEFPrintDate(dtr Date);
 char *to_utf8(int len, char *buf);
-WORD SwapWord(BYTE *p);
-DWORD SwapDWord(BYTE *p);
-DDWORD SwapDDWord(BYTE *p);
+WORD SwapWord(BYTE *p, int size);
+DWORD SwapDWord(BYTE *p, int size);
+DDWORD SwapDDWord(BYTE *p, int size);
 variableLength *MAPIFindUserProp(MAPIProps *p, unsigned int ID);
 variableLength *MAPIFindProperty(MAPIProps *p, unsigned int ID);
 BYTE *DecompressRTF(variableLength *p, int *size);


### PR DESCRIPTION
Attempting to parse 2.DATA...
==13620== Invalid read of size 4
==13620==    at 0x4E390D0: SwapDWord (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x4E3910B: TNEFPriority (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x4E3AC0D: TNEFParse (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x4E3AE3B: TNEFParseFile (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==  Address 0x5412420 is 0 bytes inside a block of size 2 alloc'd
==13620==    at 0x4C2CC70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13620==    by 0x4E3AB6C: TNEFParse (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x4E3AE3B: TNEFParseFile (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x400D09: main (in /home/stellar/a.out)
==13620==
==13620== Invalid read of size 8
==13620==    at 0x4E3A128: TNEFRendData (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x4E3AC0D: TNEFParse (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x4E3AE3B: TNEFParseFile (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x400D09: main (in /home/stellar/a.out)
==13620==  Address 0x5419b98 is 8 bytes inside a block of size 14 alloc'd
==13620==    at 0x4C2CC70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13620==    by 0x4E3AB6C: TNEFParse (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x4E3AE3B: TNEFParseFile (in /usr/lib/x86_64-linux-gnu/libytnef.so.0.0.0)
==13620==    by 0x400D09: main (in /home/stellar/a.out)
==13620==
    File saves as [Cover_Letter.pdf]
    File saves as [BSC.pdf]
    File saves as [image001.png]
==13620==
==13620== HEAP SUMMARY:
==13620==     in use at exit: 94 bytes in 7 blocks
==13620==   total heap usage: 282 allocs, 275 frees, 3,736,240 bytes allocated
==13620==
==13620== LEAK SUMMARY:
==13620==    definitely lost: 32 bytes in 5 blocks
==13620==    indirectly lost: 62 bytes in 2 blocks
==13620==      possibly lost: 0 bytes in 0 blocks
==13620==    still reachable: 0 bytes in 0 blocks
==13620==         suppressed: 0 bytes in 0 blocks
==13620== Rerun with --leak-check=full to see details of leaked memory
==13620==
==13620== For counts of detected and suppressed errors, rerun with: -v
==13620== ERROR SUMMARY: 4 errors from 2 contexts (suppressed: 0 from 0)
