### PR TITLE
ytnefprint: don't print if parsing failed

### DIFF
--- a/ytnefprint/main.c
+++ b/ytnefprint/main.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
     }
     TNEFInitialize(&TNEF);
     TNEF.Debug = verbose;
-    if (TNEFParseFile(argv[i], &TNEF) == -1) {
+    if (TNEFParseFile(argv[i], &TNEF) < 0) {
       printf("ERROR processing file\n");
       continue;
     }


### PR DESCRIPTION
The check for errors wasn't broad enough