### PR TITLE
Check size of space allocated for Date object

### DIFF
--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -655,6 +655,9 @@ int TNEFDateHandler STD_ARGLIST {
   WORD * tmp_src, *tmp_dst;
   int i;
 
+  if (size < sizeof(dtr))
+    return -1;
+
   p = &(TNEF->starting_attach);
   switch (TNEFList[id].id) {
     case attDateSent: Date = &(TNEF->dateSent); break;


### PR DESCRIPTION
Check there is enough memory allocated for the Date object before rewriting it