### PR TITLE
Fix length-check before populating propnames

### DIFF
--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -453,8 +453,8 @@ int TNEFFillMapi(TNEFStruct *TNEF, BYTE *data, DWORD size, MAPIProps *p) {
             ALLOCCHECK(mp->propnames[length - 1].data);
             mp->propnames[length - 1].size = type;
             d += 4;
+            SIZECHECK(type);
             for (j = 0; j < (type >> 1); j++) {
-              SIZECHECK(j*2);
               mp->propnames[length - 1].data[j] = d[j * 2];
             }
             d += type + ((type % 4) ? (4 - type % 4) : 0);


### PR DESCRIPTION
The earlier length check did not check enough bytes. But rather
than fixing the off-by-one, it makes more sense to do a single
check at the start of the loop.

Resolves CVE-2017-9058