### PR TITLE
Increase to_utf8 conversion limit to 100,000

### DIFF
--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -217,7 +217,7 @@ DDWORD SwapDDWord(BYTE *p, int size) {
 char *to_utf8(size_t len, char *buf) {
   int i, j = 0;
   /* worst case length */
-  if (len > 10000) {	// deal with this by adding an arbitrary limit
+  if (len > 100000) {	// deal with this by adding an arbitrary limit
      printf("suspecting a corrupt file in UTF8 conversion\n");
      exit(-1);
   }


### PR DESCRIPTION
I received a TNEF file with the following property

```
   #62: Type: [ UNICODE ]  Code: [UD:x8000]
    Name: WasclRuntimeData
    Size: 27846    Value: [<WasclRuntimeData xmlns="http://schemas.datacontract.org/2004/07/Microsoft.Exchange.Hygiene.Wascl" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
```
(truncated for sanity)

Unfortunately I can't share the TNEF file, but 27,846 bytes of utf16 data is longer than `to_utf8`'s limit of 10,000 bytes, so I increased it to 100,000