### PR TITLE
Cleanups and prealloc check

### DIFF
--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -600,7 +600,7 @@ int TNEFFillMapi(TNEFStruct *TNEF, BYTE *data, DWORD size, MAPIProps *p) {
         if (TNEF->subject.size == 0) {
           int i;
           DEBUG(TNEF->Debug, 3, "Assigning a Subject");
-          TNEF->subject.data = calloc(size+1, sizeof(BYTE));
+          TNEF->subject.data = calloc(vl->size+1, sizeof(BYTE));
           ALLOCCHECK(TNEF->subject.data);
           TNEF->subject.size = vl->size;
           memcpy(TNEF->subject.data, vl->data, vl->size);

--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -1489,23 +1489,16 @@ void MAPIPrint(MAPIProps *p) {
 
 
 int IsCompressedRTF(variableLength *p) {
-  unsigned int in;
   BYTE *src;
   ULONG magic;
 
-  if (p->size < 4)
+  if (p->size < 3*sizeof(DWORD))
     return 0;
 
   src = p->data;
-  in = 0;
+  magic = SwapDWord((BYTE*)src + 2*sizeof(DWORD), sizeof(DWORD));
 
-  in += 4;
-  in += 4;
-  magic = SwapDWord((BYTE*)src + in, 4);
-
-  if (magic == 0x414c454d) {
-    return 1;
-  } else if (magic == 0x75465a4c) {
+  if (magic == 0x414c454d || magic == 0x75465a4c) {
     return 1;
   } else {
     return 0;

--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -364,6 +364,7 @@ int TNEFRecipTable STD_ARGLIST {
   int current_prop;
 
   d = (BYTE*)data;
+  SIZECHECK(sizeof(DWORD));
   count = SwapDWord((BYTE*)d, 4);
   d += 4;
 //    printf("Recipient Table containing %u rows\n", count);
@@ -419,6 +420,7 @@ int TNEFFillMapi(TNEFStruct *TNEF, BYTE *data, DWORD size, MAPIProps *p) {
   int offset;
 
   d = data;
+  SIZECHECK(sizeof(DWORD));
   p->count = SwapDWord((BYTE*)data, 4);
   d += 4;
   // Arbitrary limit on the amount of properties
@@ -432,6 +434,7 @@ int TNEFFillMapi(TNEFStruct *TNEF, BYTE *data, DWORD size, MAPIProps *p) {
 
   for (i = 0; i < p->count; i++) {
     if (count == -1) {
+      SIZECHECK(sizeof(DWORD));
       mp->id = SwapDWord((BYTE*)d, 4);
       d += 4;
       mp->custom = 0;

--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -273,7 +273,7 @@ int TNEFMessageID STD_ARGLIST {
 // -----------------------------------------------------------------------------
 int TNEFBody STD_ARGLIST {
   TNEF->body.size = size;
-  TNEF->body.data = calloc(size, sizeof(BYTE));
+  TNEF->body.data = calloc(size+1, sizeof(BYTE));
   ALLOCCHECK(TNEF->body.data);
   memcpy(TNEF->body.data, data, size);
   return 0;
@@ -281,19 +281,19 @@ int TNEFBody STD_ARGLIST {
 // -----------------------------------------------------------------------------
 int TNEFOriginalMsgClass STD_ARGLIST {
   TNEF->OriginalMessageClass.size = size;
-  TNEF->OriginalMessageClass.data = calloc(size, sizeof(BYTE));
+  TNEF->OriginalMessageClass.data = calloc(size+1, sizeof(BYTE));
   ALLOCCHECK(TNEF->OriginalMessageClass.data);
   memcpy(TNEF->OriginalMessageClass.data, data, size);
   return 0;
 }
 // -----------------------------------------------------------------------------
 int TNEFMessageClass STD_ARGLIST {
-  memcpy(TNEF->messageClass, data, MIN(size, sizeof(TNEF->messageClass)));
+  memcpy(TNEF->messageClass, data, MIN(size, sizeof(TNEF->messageClass)-1));
   return 0;
 }
 // -----------------------------------------------------------------------------
 int TNEFFromHandler STD_ARGLIST {
-  TNEF->from.data = calloc(size, sizeof(BYTE));
+  TNEF->from.data = calloc(size+1, sizeof(BYTE));
   ALLOCCHECK(TNEF->from.data);
   TNEF->from.size = size;
   memcpy(TNEF->from.data, data, size);
@@ -304,7 +304,7 @@ int TNEFSubjectHandler STD_ARGLIST {
   if (TNEF->subject.data)
     free(TNEF->subject.data);
 
-  TNEF->subject.data = calloc(size, sizeof(BYTE));
+  TNEF->subject.data = calloc(size+1, sizeof(BYTE));
   ALLOCCHECK(TNEF->subject.data);
   TNEF->subject.size = size;
   memcpy(TNEF->subject.data, data, size);
@@ -600,7 +600,7 @@ int TNEFFillMapi(TNEFStruct *TNEF, BYTE *data, DWORD size, MAPIProps *p) {
         if (TNEF->subject.size == 0) {
           int i;
           DEBUG(TNEF->Debug, 3, "Assigning a Subject");
-          TNEF->subject.data = calloc(size, sizeof(BYTE));
+          TNEF->subject.data = calloc(size+1, sizeof(BYTE));
           ALLOCCHECK(TNEF->subject.data);
           TNEF->subject.size = vl->size;
           memcpy(TNEF->subject.data, vl->data, vl->size);


### PR DESCRIPTION
- add some missing `SIZECHECK` calls
- fixed an incorrect `SIZECHECK` in `IsCompressedRTF`
- more consistent use of `sizeof(DWORD)` instead of `4`
- allocating an extra byte for string-like fields to guarantee null-termination
- fixed an incorrect size argument to `calloc`
- impose a maximum size limit on calls to `calloc` with a new macro `PREALLOCCHECK`. This is probably the most intrusive change and could use strict review to check that the limits are appropriate.