### PR TITLE
Added `-fsanitize=address` to the LDFLAGS as well

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -4,7 +4,7 @@ mkdir -p m4
 autoreconf -vfi
 ./configure --disable-dependency-tracking
 if [ "$TRAVIS_OS_NAME" == "osx" ] || [ "$CC" == "clang" ]; then
-  make CFLAGS="-fsanitize=address -g"
+  make CFLAGS="-fsanitize=address -g" LDFLAGS="-fsanitize=address"
 else
   make
 fi


### PR DESCRIPTION
This resolves a build (travis) failure in the OSX builds where the
asan versions of functions were unresolved during link-stage.

I think this is related to a new XCode/OSX deployment.