### PR TITLE
Fat attachments

### DIFF
--- a/lib/tnef-types.h
+++ b/lib/tnef-types.h
@@ -129,6 +129,7 @@ typedef struct {
   int RequestRes;
   int Debug;
   TNEFIOStruct IO;
+  int attachmentSize;
 } TNEFStruct;
 
 #endif

--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -1180,7 +1180,7 @@ int TNEFParse(TNEFStruct *TNEF) {
       printf("ERROR: Field with size of 0\n");
       return YTNEF_ERROR_READING_DATA;
     }
-    PREALLOCCHECK(size, 1000000);
+    PREALLOCCHECK(size, 50*1024*1024);
     data = calloc(size, sizeof(BYTE));
     ALLOCCHECK(data);
     if (TNEFRawRead(TNEF, data, size, &header_checksum) < 0) {

--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -961,6 +961,7 @@ void TNEFInitialize(TNEFStruct *TNEF) {
   TNEF->IO.InitProc = NULL;
   TNEF->IO.ReadProc = NULL;
   TNEF->IO.CloseProc = NULL;
+  TNEF->attachmentSize = 50;
 }
 #undef INITVARLENGTH
 #undef INITDTR
@@ -1180,7 +1181,7 @@ int TNEFParse(TNEFStruct *TNEF) {
       printf("ERROR: Field with size of 0\n");
       return YTNEF_ERROR_READING_DATA;
     }
-    PREALLOCCHECK(size, 50*1024*1024);
+    PREALLOCCHECK(size, TNEF->attachmentSize*1024*1024);
     data = calloc(size, sizeof(BYTE));
     ALLOCCHECK(data);
     if (TNEFRawRead(TNEF, data, size, &header_checksum) < 0) {

--- a/ytnef/main.c
+++ b/ytnef/main.c
@@ -32,6 +32,7 @@ int verbose = 0;
 int savefiles = 0;
 int saveRTF = 0;
 int saveintermediate = 0;
+int attachmentSize = 50;
 char *filepath = NULL;
 int ProcessTNEF(TNEFStruct TNEF);
 void SaveVCalendar(TNEFStruct TNEF, int isMtgReq);
@@ -51,6 +52,7 @@ void PrintHelp(void) {
   printf("   -/+f - Enables/Disables saving of attachments\n");
   printf("   -/+F - Enables/Disables saving of the message body as RTF\n");
   printf("   -/+a - Enables/Disables saving of intermediate files\n");
+  printf("   -s <n> - Override the default Attachment Size (%i MB)\n", attachmentSize);
   printf("   -h   - Displays this help message\n");
   printf("\n");
   printf("Example:\n");
@@ -94,6 +96,10 @@ int main(int argc, char **argv) {
           filepath = argv[i + 1];
           i++;
           break;
+        case 's': 
+          attachmentSize = atoi(argv[i+1]);
+          i++;
+          break;
         case 'F': saveRTF = 1;
           break;
         default:
@@ -122,6 +128,7 @@ int main(int argc, char **argv) {
 
     TNEFInitialize(&TNEF);
     TNEF.Debug = verbose;
+    TNEF.attachmentSize = attachmentSize;
     if (TNEFParseFile(argv[i], &TNEF) == -1) {
       fprintf(stderr, "ERROR processing file\n");
       ++errors;
@@ -286,6 +293,7 @@ int ProcessTNEF(TNEFStruct TNEF) {
         if (TNEFCheckForSignature(signature) == 0) {
           // Has a TNEF signature, so process it.
           TNEFInitialize(&emb_tnef);
+          emb_tnef.attachmentSize = attachmentSize;
           emb_tnef.Debug = TNEF.Debug;
           if (TNEFParseMemory(filedata->data + 16,
                               filedata->size - 16, &emb_tnef) != -1) {
@@ -301,6 +309,7 @@ int ProcessTNEF(TNEFStruct TNEF) {
         if (TNEFCheckForSignature(signature) == 0) {
           // Has a TNEF signature, so process it.
           TNEFInitialize(&emb_tnef);
+          emb_tnef.attachmentSize = attachmentSize;
           emb_tnef.Debug = TNEF.Debug;
           if (TNEFParseMemory(filedata->data,
                               filedata->size, &emb_tnef) != -1) {

--- a/ytnefprint/main.c
+++ b/ytnefprint/main.c
@@ -28,6 +28,7 @@
 
 TNEFStruct TNEF;
 int verbose = 0;
+int attachmentSize = 50;
 void PrintTNEF(TNEFStruct TNEF);
 void ProcessTNEF(TNEFStruct TNEF);
 void SaveVCalendar(TNEFStruct TNEF);
@@ -44,6 +45,7 @@ void PrintHelp(void) {
   printf("\n");
   printf("Options:\n");
   printf("   -h   - Displays this help message\n");
+  printf("   -s <n> - Override the default max attachment size (%i MB)\n", attachmentSize);
   printf("   -v   - Verbose output (multiple -v's increase \n");
   printf("                   the level of output.\n");
   printf("\n");
@@ -77,6 +79,7 @@ int main(int argc, char **argv) {
     }
     TNEFInitialize(&TNEF);
     TNEF.Debug = verbose;
+    TNEF.attachmentSize = attachmentSize;
     if (TNEFParseFile(argv[i], &TNEF) < 0) {
       printf("ERROR processing file\n");
       continue;


### PR DESCRIPTION
Raised the default maximum attachment size to 50MB.

Added a new variable '-s' to both 'ytnef' and 'ytnefprint' that allows the user to override the default 50MB attachment size.