### PR TITLE
Prevent potential double-free in TNEFSubjectHandler

### DIFF
--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -301,8 +301,10 @@ int TNEFFromHandler STD_ARGLIST {
 }
 // -----------------------------------------------------------------------------
 int TNEFSubjectHandler STD_ARGLIST {
-  if (TNEF->subject.data)
+  if (TNEF->subject.data) {
     free(TNEF->subject.data);
+    TNEF->subject.data = NULL;
+  }
 
   PREALLOCCHECK(size, 100);
   TNEF->subject.data = calloc(size+1, sizeof(BYTE));


### PR DESCRIPTION
If TNEFSubjectHandler is called multiple times, but the last time
failed due to the PREALLOCCHECK, the subject.data member will be
a freed, but invalid pointer. To prevent a double-free next time
TNEFSubjectHandler is entered, set it to zero after freeing.

Resolves: #85
Reported-by: jasperla