### PR TITLE
Ensure the size of the version field is 4 bytes

### DIFF
--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -335,6 +335,10 @@ int TNEFRendData STD_ARGLIST {
 int TNEFVersion STD_ARGLIST {
   WORD major;
   WORD minor;
+  if (size != 2 * sizeof(WORD)) {
+    printf("Incorrect size of version field, suspected corruption\n");
+    return -1;
+  }
   minor = SwapWord((BYTE*)data, size);
   major = SwapWord((BYTE*)data + 2, size - 2);
 


### PR DESCRIPTION
A corrupted version field size can cause TNEFVersion to access outside
of allocated memory. Check the version is the expected size and raise
an error if not.

Resolves: #86
Reported-by: jasperla