### PR TITLE
Increase filename limit to 260 bytes

### DIFF
--- a/lib/ytnef.c
+++ b/lib/ytnef.c
@@ -783,7 +783,7 @@ int TNEFAttachmentFilename STD_ARGLIST {
   while (p->next != NULL) p = p->next;
 
   p->Title.size = size;
-  PREALLOCCHECK(size, 100);
+  PREALLOCCHECK(size, 260);
   p->Title.data = calloc(size+1, sizeof(BYTE));
   ALLOCCHECK(p->Title.data);
   memcpy(p->Title.data, data, size);


### PR DESCRIPTION
Filename limit should be increased to 260 bytes as per [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry) 